### PR TITLE
More forgiving empty lines around comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Head
+
+* Fixed: more forgiving empty lines rules when comments are present i.e. the `rule-non-nested-empty-line-before` and `at-rule-empty-line-before` now make use of the `ignore: ["after-comment"]` option.
+
 # 0.2.0
 
 * Added: `block-no-empty` rule.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ It favours flexibility over strictness for things like multi-line lists and sing
 .selector-3[type="text"] {
   background: linear-gradient(#fff, rgba(0, 0, 0, 0.8));
   box-sizing: border-box;
-  display: block;  
+  display: block;
   color: #333;
 }
 
@@ -52,6 +52,7 @@ It favours flexibility over strictness for things like multi-line lists and sing
   }
 }
 
+/* Flush single line comment */
 @media screen and (min-device-pixel-ratio: 2),
   screen and (min-resolution: 192dpi),
   screen and (min-resolution: 2dppx) {
@@ -73,6 +74,7 @@ It favours flexibility over strictness for things like multi-line lists and sing
     height: 10rem;
   }
 
+  /* Flush nested single line comment */
   .selector::after {
     content: "→";
     background-image: url("x.svg");

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -41,6 +41,7 @@ const validCss = (
   }
 }
 
+/* Flush single line comment */
 @media screen and (min-device-pixel-ratio: 2),
   screen and (min-resolution: 192dpi),
   screen and (min-resolution: 2dppx) {
@@ -62,6 +63,7 @@ const validCss = (
     height: 10rem;
   }
 
+  /* Flush nested single line comment */
   .selector::after {
     content: "→";
     background-image: url("x.svg");

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,6 @@ environment:
 version: "{build}"
 build: off
 deploy: off
-cache: [node_modules]
 
 install:
   - ps: Install-Product node $env:nodejs_version
@@ -16,5 +15,4 @@ install:
 test_script:
   - node --version
   - npm --version
-  - ps: "npm test # PowerShell"
   - cmd: "npm test"

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ module.exports = {
   "rules": {
     "at-rule-empty-line-before": [ "always", {
       except: ["blockless-group"],
+      ignore: ["after-comment"],
     } ],
     "block-closing-brace-newline-after": "always",
     "block-closing-brace-newline-before": "always-multi-line",
@@ -48,7 +49,9 @@ module.exports = {
     "number-no-trailing-zeros": true,
     "number-zero-length-no-unit": true,
     "rule-no-shorthand-property-overrides": true,
-    "rule-non-nested-empty-line-before": "always-multi-line",
+    "rule-non-nested-empty-line-before": [ "always-multi-line", {
+      ignore: ["after-comment"],
+    } ],
     "rule-trailing-semicolon": "always",
     "selector-combinator-space-after": "always",
     "selector-combinator-space-before": "always",


### PR DESCRIPTION
Just noticed that [one of the first configs to extend standard](https://github.com/jongleberry/stylelint-config-jongleberry/blob/master/lib/index.js#L13) loosens up the empty lines around comments.

I should of done this originally.

@davidtheclark What do you think?