### PR TITLE
Clarify the range

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "stylelint": "^4.5.0"
   },
   "peerDependencies": {
-    "stylelint": ">=4.5.0 <6.0.0"
+    "stylelint": "^4.5.0 || ^5.0.0"
   },
   "scripts": {
     "ava": "ava --verbose \"__tests__/**/*.js\"",


### PR DESCRIPTION
Use a clearer method of specifying the range of compatible versions. Pointed out by @ntwb in https://github.com/ntwb/stylelint-config-wordpress/pull/41.