### PR TITLE
Travis & AppVeyor CI performance tweaks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,17 @@
 sudo: false
 
+git:
+  depth: 1
+
+branches:
+  only:
+    - master
+
 language: node_js
+
+cache:
+  directories:
+    - node_modules
+
 node_js:
-  - stable
+  - '5'

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,14 @@ branches:
 
 language: node_js
 
+# cache node modules
 cache:
   directories:
     - node_modules
 
 node_js:
   - '5'
+
+before_install:
+  # remove outdated deps, assists with cache maintenance
+  - npm prune

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,11 @@ environment:
 version: "{build}"
 build: off
 deploy: off
-
+branches:
+  only:
+    - master
+clone_depth: 1
+skip_tags: true
 install:
   - ps: Install-Product node $env:nodejs_version
   - npm install


### PR DESCRIPTION
• Shallow clones the `stylelint-config-standard` repo for improved performance
• Only build the master branch (preventing duplicate builds on PRs)
• Cache the `node_modules` directory improving `npm install` performance
• Switch to NodeJS alias `5` over deprecated `stable` alias