### PR TITLE
CI: Use the latest NodeJS on Travis CI & AppVeyor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ cache:
     - node_modules
 
 node_js:
-  - '5'
+  - '6'
 
 before_install:
   # remove outdated deps, assists with cache maintenance

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@
 
 environment:
   matrix:
-    - nodejs_version: 5
+    - nodejs_version: 6
 
 version: "{build}"
 build: off


### PR DESCRIPTION
> Node.js v5 will continue to be supported for the next two months in order to give developers currently using v5 time to transition to Node.js v6. - https://nodejs.org/en/blog/release/v6.0.0/