### PR TITLE
Add more simple usage for globally installed configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,14 @@ If you've globally installed `stylelint-config-standard` using the `-g` flag, th
 }
 ```
 
+Since [stylelint 9.7.0](https://github.com/stylelint/stylelint/blob/9.7.0/CHANGELOG.md#970), you can simply use the globally installed configuration name instead of the absolute path:
+
+```json
+{
+  "extends": "stylelint-config-standard"
+}
+```
+
 ### Extending the config
 
 Simply add a `"rules"` key to your config, then add your overrides and additions there.


### PR DESCRIPTION
See also:
- https://github.com/stylelint/stylelint/blob/9.7.0/CHANGELOG.md#970
- https://github.com/stylelint/stylelint/pull/3642

Perhaps we should also fix the README of `stylelint-config-recommended`:

https://github.com/stylelint/stylelint-config-recommended/blob/eb56af0fcd8d7031b560da570175ac980d3bec09/README.md#usage