### PR TITLE
Explicitly list supported stylelint versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "stylelint": "^13.2.0"
   },
   "peerDependencies": {
-    "stylelint": ">=10.1.0"
+    "stylelint": "^10.1.0 || ^11.0.0 || ^12.0.0 || ^13.0.0"
   },
   "scripts": {
     "format": "prettier . --write",


### PR DESCRIPTION
Currently version of config claims even support `stylelint@100`. I'm not sure it would be the case :)

Fixes #137.