### PR TITLE
Change alpha-value-notation for opacity property

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,12 @@
 module.exports = {
 	extends: 'stylelint-config-recommended',
 	rules: {
-		'alpha-value-notation': 'percentage',
+		'alpha-value-notation': [
+			'percentage',
+			{
+				exceptProperties: ['opacity']
+			}
+		],
 		'at-rule-empty-line-before': [
 			'always',
 			{


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #210

> Is there anything in the PR that needs further explanation?

e.g. "No, it's self-explanatory."
