### PR TITLE
Change alpha-value-notation to be "number"`for opacity property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 24.0.0
+
+- Changed: `alpha-value-notation` to be `"number"` for `opacity` property.
+
 ## 23.0.0
 
 This release adds over a dozen new rules.

--- a/README.md
+++ b/README.md
@@ -93,8 +93,8 @@ To see the rules that this config uses, please read the [config itself](./index.
 }
 
 @keyframes fade-in {
-  from { opacity: 0%; }
-  to { opacity: 100%; }
+  from { opacity: 0; }
+  to { opacity: 1; }
 }
 ```
 

--- a/__tests__/valid.css
+++ b/__tests__/valid.css
@@ -74,6 +74,6 @@
 }
 
 @keyframes fade-in {
-  from { opacity: 0%; }
-  to { opacity: 100%; }
+  from { opacity: 0; }
+  to { opacity: 1; }
 }

--- a/index.js
+++ b/index.js
@@ -3,7 +3,12 @@
 module.exports = {
 	extends: 'stylelint-config-recommended',
 	rules: {
-		'alpha-value-notation': 'percentage',
+		'alpha-value-notation': [
+			'percentage',
+			{
+				exceptProperties: ['opacity'],
+			},
+		],
 		'at-rule-empty-line-before': [
 			'always',
 			{


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes https://github.com/stylelint/stylelint-config-standard/issues/210
Supersedes https://github.com/stylelint/stylelint-config-standard/pull/211

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
