### PR TITLE
Fix `value-no-vendor-prefix` for `-webkit-box`

### DIFF
--- a/index.js
+++ b/index.js
@@ -166,6 +166,12 @@ module.exports = {
 		'value-list-comma-space-after': 'always-single-line',
 		'value-list-comma-space-before': 'never',
 		'value-list-max-empty-lines': 0,
-		'value-no-vendor-prefix': true,
+		'value-no-vendor-prefix': [
+			true,
+			{
+				// `-webkit-box` is allowed as standard. See https://www.w3.org/TR/css-overflow-3/#webkit-line-clamp
+				ignoreValues: ['box'],
+			},
+		],
 	},
 };


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes https://github.com/stylelint/stylelint/issues/6372

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
