### PR TITLE
Fix `value-no-vendor-prefix` for `-webkit-inline-box`

### DIFF
--- a/index.js
+++ b/index.js
@@ -170,7 +170,7 @@ module.exports = {
 			true,
 			{
 				// `-webkit-box` is allowed as standard. See https://www.w3.org/TR/css-overflow-3/#webkit-line-clamp
-				ignoreValues: ['box'],
+				ignoreValues: ['box', 'inline-box'],
 			},
 		],
 	},


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

stylelint/stylelint#6372

> Is there anything in the PR that needs further explanation?

https://github.com/stylelint/stylelint-config-standard/pull/261#issuecomment-1362220299
`-moz-box` and `-moz-inline-box` cannot be excluded