### PR TITLE
Add `engines.node` field to `package.json`

### DIFF
--- a/__tests__/engines.test.js
+++ b/__tests__/engines.test.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const { execFileSync } = require('child_process');
+const pkg = require('../package.json');
+
+describe('engines.node', () => {
+	it("is the same as stylelint's one", () => {
+		const stylelintVersion = pkg.peerDependencies.stylelint;
+		const [nodeVersion] = JSON.parse(
+			execFileSync('npm', [
+				'view',
+				'--json',
+				`stylelint@${stylelintVersion}`,
+				'engines.node',
+			]).toString(),
+		);
+
+		expect(nodeVersion).toEqual(pkg.engines.node);
+	});
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,9 @@
         "remark-cli": "^11.0.0",
         "stylelint": "^15.8.0"
       },
+      "engines": {
+        "node": "^14.13.1 || >=16.0.0"
+      },
       "peerDependencies": {
         "stylelint": "^15.5.0"
       }

--- a/package.json
+++ b/package.json
@@ -66,5 +66,8 @@
   },
   "peerDependencies": {
     "stylelint": "^15.5.0"
+  },
+  "engines": {
+    "node": "^14.13.1 || >=16.0.0"
   }
 }


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Ref: https://github.com/stylelint/stylelint-config-recommended/pull/195

> Is there anything in the PR that needs further explanation?

The `engines.node` field should be the same as `stylelint`'s `engines.node` (peer dependency).

https://github.com/stylelint/stylelint-config-standard/blob/dc2e7564b5fb72067a85fb04da913a14779d0461/package.json#L67-L69