### PR TITLE
Add ESLint to dependabot dev group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,7 @@ updates:
     groups:
       development-dependencies:
         dependency-type: 'development'
-        exclude-patterns: ['stylelint', 'eslint']
+        exclude-patterns: ['stylelint']
     ignore:
       - dependency-name: 'stylelint' # Avoid updating the peer dependency.
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None

> Is there anything in the PR that needs further explanation?

We can re-add ESLint now that we use 9.x.
